### PR TITLE
Ensure cuid1 works under wasm

### DIFF
--- a/crates/cuid1/Cargo.toml
+++ b/crates/cuid1/Cargo.toml
@@ -14,6 +14,7 @@ maintenance = { status = "deprecated" }
 
 [dev-dependencies]
 criterion = "~0.3"
+wasm-bindgen-test = "0.3.38"
 
 [dependencies]
 base36 = "0.0.1"
@@ -23,6 +24,11 @@ num = { version = "0.4.0", features = ["num-bigint"] }
 once_cell = "1.9.0"
 rand = "~0.8.0"
 sha3 = "0.10.8"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.11", features = ["js"] }
+js-sys = "0.3.65"
+
 
 [lib]
 name = "cuid"

--- a/crates/cuid1/src/cuid1/fingerprint.rs
+++ b/crates/cuid1/src/cuid1/fingerprint.rs
@@ -1,6 +1,7 @@
 use num::bigint;
 use rand::{thread_rng, Rng};
 use sha3::{Digest, Sha3_512};
+#[cfg(not(target_arch = "wasm32"))]
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
@@ -34,13 +35,16 @@ thread_local! {
         [
             thread_rng().gen::<u128>().to_be_bytes(),
             thread_rng().gen::<u128>().to_be_bytes(),
+            #[cfg(not(target_arch="wasm32"))]
             u128::from(std::process::id()).to_be_bytes(),
+            #[cfg(not(target_arch="wasm32"))]
             u128::from(get_thread_id()).to_be_bytes(),
         ],
         BIG_LENGTH.into(),
     );
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 /// Retrieves the current thread's ID.
 fn get_thread_id() -> u64 {
     // ThreadId doesn't implement debug or display, but it does implement Hash,

--- a/crates/cuid1/src/time/mod.rs
+++ b/crates/cuid1/src/time/mod.rs
@@ -1,0 +1,10 @@
+#[cfg(not(target_arch = "wasm32"))]
+mod native;
+#[cfg(target_arch = "wasm32")]
+mod wasm;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use native::*;
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::*;

--- a/crates/cuid1/src/time/native.rs
+++ b/crates/cuid1/src/time/native.rs
@@ -14,8 +14,8 @@ pub fn timestamp() -> Result<String, CuidError> {
 
 #[cfg(test)]
 mod time_tests {
-    use super::super::BASE;
     use super::*;
+    use crate::BASE;
 
     // NOTE: this will start failing in ~2059, at which point this will need to
     // be updated to 9

--- a/crates/cuid1/src/time/wasm.rs
+++ b/crates/cuid1/src/time/wasm.rs
@@ -1,0 +1,7 @@
+use crate::error::CuidError;
+use crate::text::to_base_string;
+use js_sys::Date;
+
+pub fn timestamp() -> Result<String, CuidError> {
+    to_base_string(Date::now().round() as u128)
+}

--- a/crates/cuid1/tests/wasm.rs
+++ b/crates/cuid1/tests/wasm.rs
@@ -1,0 +1,8 @@
+use cuid::cuid;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn example() {
+    let id = cuid().unwrap();
+    assert!(id.len() == 25);
+}

--- a/crates/cuid1/tests/wasm.rs
+++ b/crates/cuid1/tests/wasm.rs
@@ -2,7 +2,7 @@ use cuid::cuid;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]
-fn example() {
+fn cuid_length() {
     let id = cuid().unwrap();
     assert!(id.len() == 25);
 }


### PR DESCRIPTION
Fixes 2 dependecies when run on wasm
- Uses `Date.now()` instead of `SystemDateTime`
- Excudes pid and thread id

Close prisma/team-orm#628